### PR TITLE
Move upcoming events next to intro video

### DIFF
--- a/frontend/src/pages/index/css/index.css
+++ b/frontend/src/pages/index/css/index.css
@@ -6,7 +6,7 @@
 #hero {
   position: relative;
   height: 90vh;
-  background: url('../../../assets/images/hero/hero.jpg') center/cover no-repeat;
+  background: url("../../../assets/images/hero/hero.jpg") center/cover no-repeat;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -16,7 +16,8 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg,
+  background: linear-gradient(
+    135deg,
     rgba(0, 86, 166, 0.7),
     rgba(0, 0, 0, 0.3)
   );
@@ -30,14 +31,14 @@
 .hero-content h1 {
   font-size: clamp(2.5rem, 5vw, 4rem);
   margin-bottom: 1rem;
-  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 .hero-content p {
   font-size: clamp(1rem, 2.5vw, 1.5rem);
   margin-bottom: 2rem;
 }
 .hero-buttons .btn {
-  margin: 0 .5rem;
+  margin: 0 0.5rem;
   min-width: 140px;
 }
 
@@ -50,7 +51,35 @@
 .video-section video {
   max-width: 100%;
   border-radius: var(--radius);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* layout for video and events side by side */
+.video-events {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+}
+.video-wrapper {
+  flex: 1;
+  margin-left: -1rem;
+}
+.events-wrapper {
+  flex: 1;
+}
+.events-grid {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+.events-grid li {
+  background: var(--background-main);
+  padding: 1rem;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 /* ─── News Section ─────────────────────────────────────────────────────── */
@@ -64,7 +93,7 @@
 }
 .news-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px,1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.5rem;
   margin-top: 1rem;
 }
@@ -72,12 +101,14 @@
   background: #fff;
   border-left: 4px solid var(--secondary-color);
   border-radius: var(--radius);
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  transition: transform .2s, box-shadow .2s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
 }
 .news-list li:hover {
   transform: translateY(-4px);
-  box-shadow: 0 6px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
 }
 .news-list a {
   display: block;
@@ -85,11 +116,11 @@
   color: var(--text-main);
 }
 .news-list h3 {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   color: var(--primary-color);
 }
 .news-list time {
-  font-size: .85rem;
+  font-size: 0.85rem;
   color: #666;
 }
 
@@ -101,7 +132,7 @@
   align-items: center;
 }
 .about-text h2 {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 .about-text p {
   font-size: 1.1rem;
@@ -110,7 +141,7 @@
 .about-image img {
   width: 100%;
   border-radius: var(--radius);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   object-fit: cover;
 }
 
@@ -126,8 +157,10 @@
   border-radius: var(--radius);
   padding: 1.5rem;
   border-top: 4px solid var(--primary-color);
-  box-shadow: 0 1px 4px rgba(0,0,0,0.05);
-  transition: transform .3s, box-shadow .3s;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  transition:
+    transform 0.3s,
+    box-shadow 0.3s;
   position: relative;
 }
 .issues-list li::before {
@@ -142,7 +175,7 @@
 }
 .issues-list li:hover {
   transform: translateY(-5px);
-  box-shadow: 0 6px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
 }
 
 .section.issues h2 {
@@ -151,11 +184,11 @@
 }
 .issues-list li h3 {
   color: var(--primary-color);
-  margin-bottom: .75rem;
+  margin-bottom: 0.75rem;
 }
 .issues-list li p {
   color: var(--text-main);
-  font-size: .95rem;
+  font-size: 0.95rem;
   line-height: 1.6;
 }
 
@@ -174,42 +207,6 @@
   background: var(--container-background);
 }
 
-/* 5) Events Section — Vertical timeline */
-.events-list {
-  position: relative;
-  margin-top: 2rem;
-  padding-left: 2rem;
-}
-.events-list::before {
-  content: "";
-  position: absolute;
-  left: 1rem;
-  top: 0;
-  bottom: 0;
-  width: 4px;
-  background: var(--primary-color);
-}
-.events-list li {
-  position: relative;
-  margin-bottom: 1.5rem;
-  padding-left: 1.5rem;
-}
-.events-list li::before {
-  content: "";
-  position: absolute;
-  left: -8px;
-  top: 0;
-  width: 16px;
-  height: 16px;
-  background: var(--primary-color);
-  border-radius: 50%;
-}
-.events-list li strong {
-  display: block;
-  margin-bottom: .25rem;
-  color: var(--text-main);
-}
-
 /* 6) Contact Section — Centered card */
 .section.contact .container {
   display: flex;
@@ -224,9 +221,10 @@
 
 /* 7) Responsive tweaks */
 @media (max-width: 768px) {
-  #hero { height: 70vh; }
-  .section.about .container { grid-template-columns: 1fr; }
-  .events-list::before { left: .5rem; }
-  .events-list li { padding-left: 1rem; }
-  .events-list li::before { left: -6px; width: 12px; height: 12px; }
+  #hero {
+    height: 70vh;
+  }
+  .section.about .container {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/src/pages/index/index.html
+++ b/frontend/src/pages/index/index.html
@@ -28,18 +28,38 @@
           <p>Your Voice. Your Future. Our Community.</p>
           <div class="hero-buttons">
             <a href="#volunteer" class="btn btn-primary">Volunteer</a>
-            <a href="#donate"    class="btn btn-secondary">Donate</a>
+            <a href="#donate" class="btn btn-secondary">Donate</a>
           </div>
         </div>
       </section>
 
-      <!-- Video Intro -->
+      <!-- Video Intro and Upcoming Events -->
       <section id="video" class="section video-section">
-        <div class="container">
-          <video controls preload="metadata" poster="../../assets/images/hero/hero.jpg">
-            <!-- <source src="assets/videos/intro.mp4" type="video/mp4"> -->
-            Your browser does not support HTML5 video.
-          </video>
+        <div class="container video-events">
+          <div class="video-wrapper">
+            <video
+              controls
+              preload="metadata"
+              poster="../../assets/images/hero/hero.jpg"
+            >
+              <!-- <source src="assets/videos/intro.mp4" type="video/mp4"> -->
+              Your browser does not support HTML5 video.
+            </video>
+          </div>
+          <div class="events-wrapper">
+            <h2>Upcoming Events</h2>
+            <ul class="events-grid">
+              <li>
+                <strong>July 4, 2025</strong> — Independence Day Parade in Great
+                Falls
+              </li>
+              <li>
+                <strong>July 12, 2025</strong> — Town Hall Meeting at Community
+                Center
+              </li>
+              <li><strong>July 20, 2025</strong> — Volunteer Kickoff BBQ</li>
+            </ul>
+          </div>
         </div>
       </section>
 
@@ -48,10 +68,18 @@
         <div class="container">
           <div class="about-text">
             <h2>About Sam Lux</h2>
-            <p>Sam Lux is a proud Montanan and small-business owner fighting to bring real change to MT-02. Committed to fiscal responsibility, quality healthcare, and education reform, [he/she/they] will always put constituents first.</p>
+            <p>
+              Sam Lux is a proud Montanan and small-business owner fighting to
+              bring real change to MT-02. Committed to fiscal responsibility,
+              quality healthcare, and education reform, [he/she/they] will
+              always put constituents first.
+            </p>
           </div>
           <div class="about-image">
-            <img src="../../assets/images/icons/defaultAvatar.png" alt="Sam Lux">
+            <img
+              src="../../assets/images/icons/defaultAvatar.png"
+              alt="Sam Lux"
+            />
           </div>
         </div>
       </section>
@@ -84,7 +112,6 @@
         </div>
       </section>
 
-
       <!-- Issues -->
       <section id="issues" class="section issues">
         <div class="container">
@@ -96,19 +123,29 @@
             </li>
             <li id="housing">
               <h3>Housing Affordability</h3>
-              <p>Making homeownership and rental housing accessible in rural & urban MT.</p>
+              <p>
+                Making homeownership and rental housing accessible in rural &
+                urban MT.
+              </p>
             </li>
             <li id="immigration">
               <h3>Immigration, Border Security &amp; Crime</h3>
-              <p>Balanced reform that secures our borders while supporting our workforce.</p>
+              <p>
+                Balanced reform that secures our borders while supporting our
+                workforce.
+              </p>
             </li>
             <li id="agriculture">
               <h3>Agriculture &amp; Rural Livelihoods</h3>
-              <p>Supporting Montana’s farmers, ranchers, and rural communities.</p>
+              <p>
+                Supporting Montana’s farmers, ranchers, and rural communities.
+              </p>
             </li>
             <li id="energy">
               <h3>Energy Production &amp; Environmental Stewardship</h3>
-              <p>Investing in clean energy while protecting our public lands.</p>
+              <p>
+                Investing in clean energy while protecting our public lands.
+              </p>
             </li>
             <li id="health">
               <h3>Health Care &amp; Social Services</h3>
@@ -116,7 +153,10 @@
             </li>
             <li id="education">
               <h3>Education &amp; Community Values</h3>
-              <p>Strengthening schools, supporting teachers, and promoting civic engagement.</p>
+              <p>
+                Strengthening schools, supporting teachers, and promoting civic
+                engagement.
+              </p>
             </li>
             <li id="guns">
               <h3>Gun Rights &amp; Second Amendment</h3>
@@ -124,16 +164,21 @@
             </li>
             <li id="social">
               <h3>Social &amp; Cultural Issues</h3>
-              <p>Defending personal freedoms from abortion access to LGBTQ+ rights.</p>
+              <p>
+                Defending personal freedoms from abortion access to LGBTQ+
+                rights.
+              </p>
             </li>
             <li id="tribal">
               <h3>Tribal Community Support &amp; Infrastructure</h3>
-              <p>Partnering with Tribal Nations for economic opportunity and services.</p>
+              <p>
+                Partnering with Tribal Nations for economic opportunity and
+                services.
+              </p>
             </li>
           </ul>
         </div>
       </section>
-
 
       <!-- Get Involved -->
       <section id="get-involved" class="section get-involved">
@@ -141,20 +186,8 @@
           <h2>Get Involved</h2>
           <div class="hero-buttons">
             <a href="#volunteer" class="btn btn-primary">Volunteer</a>
-            <a href="#donate"    class="btn btn-secondary">Donate</a>
+            <a href="#donate" class="btn btn-secondary">Donate</a>
           </div>
-        </div>
-      </section>
-
-      <!-- Events -->
-      <section id="events" class="section events">
-        <div class="container">
-          <h2>Upcoming Events</h2>
-          <ul class="events-list">
-            <li><strong>July 4, 2025</strong> — Independence Day Parade in Great Falls</li>
-            <li><strong>July 12, 2025</strong> — Town Hall Meeting at Community Center</li>
-            <li><strong>July 20, 2025</strong> — Volunteer Kickoff BBQ</li>
-          </ul>
         </div>
       </section>
 
@@ -163,7 +196,8 @@
         <div class="container">
           <h2>Contact Us</h2>
           <p>
-            Have questions? <a href="mailto:campaign@[yourdomain].org">Email the Campaign</a>
+            Have questions?
+            <a href="mailto:campaign@[yourdomain].org">Email the Campaign</a>
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- combine events list with the intro video section
- style video and events side-by-side
- remove old standalone events section

## Testing
- `npm run lint` *(fails: Cannot find module 'globals')*
- `npm run format`
- `npm run build:frontend` *(fails: webpack not found)*
- `npm run start:backend` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685c3c44111c832888f770acc9fcd606