### PR TITLE
Add coalition signup workflow and countdown

### DIFF
--- a/backend/src/models/coalitionSignup.js
+++ b/backend/src/models/coalitionSignup.js
@@ -1,0 +1,18 @@
+const { DataTypes } = require("sequelize");
+const sequelize = require("../config/database");
+
+const CoalitionSignup = sequelize.define(
+  "CoalitionSignup",
+  {
+    name: { type: DataTypes.STRING, allowNull: false },
+    email: { type: DataTypes.STRING, allowNull: false },
+    phone: { type: DataTypes.STRING, allowNull: false },
+    zip: { type: DataTypes.STRING, allowNull: false },
+  },
+  {
+    tableName: "coalition_signups",
+    timestamps: true,
+  },
+);
+
+module.exports = CoalitionSignup;

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -5,6 +5,7 @@ const ContactMessage = require("../models/contactMessage");
 const Volunteer = require("../models/volunteer");
 const EventSignup = require("../models/eventSignup");
 const MailingListSignup = require("../models/mailingListSignup");
+const CoalitionSignup = require("../models/coalitionSignup");
 
 router.use(ensureAdmin);
 
@@ -65,6 +66,18 @@ router.get("/event-signups", async (_req, res) => {
     res.json(signups);
   } catch (err) {
     console.error("Fetch event signups error:", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+router.get("/coalition-signups", async (_req, res) => {
+  try {
+    const signups = await CoalitionSignup.findAll({
+      order: [["createdAt", "DESC"]],
+    });
+    res.json(signups);
+  } catch (err) {
+    console.error("Fetch coalition signups error:", err);
     res.status(500).json({ error: "Server error" });
   }
 });

--- a/backend/src/routes/coalitionSignups.js
+++ b/backend/src/routes/coalitionSignups.js
@@ -1,0 +1,31 @@
+const express = require("express");
+const router = express.Router();
+const CoalitionSignup = require("../models/coalitionSignup");
+
+router.post("/", async (req, res) => {
+  try {
+    const { name, email, phone, zip } = req.body;
+    if (!name || !email || !phone || !zip) {
+      return res.status(400).json({ error: "All fields are required" });
+    }
+
+    const trimmed = {
+      name: String(name).trim(),
+      email: String(email).trim(),
+      phone: String(phone).trim(),
+      zip: String(zip).trim(),
+    };
+
+    if (!trimmed.name || !trimmed.email || !trimmed.phone || !trimmed.zip) {
+      return res.status(400).json({ error: "All fields are required" });
+    }
+
+    const signup = await CoalitionSignup.create(trimmed);
+    res.status(201).json({ id: signup.id });
+  } catch (err) {
+    console.error("Coalition signup error:", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -103,6 +103,7 @@ const { RedisStore } = require("connect-redis");
   const contactRoutes = require("./routes/contactMessages");
   const eventRoutes = require("./routes/events");
   const coalitionRoutes = require("./routes/coalitionCandidates");
+  const coalitionSignupRoutes = require("./routes/coalitionSignups");
   const signupRoutes = require("./routes/eventSignups");
   const mailingListRoutes = require("./routes/mailingList");
   const adminRoutes = require("./routes/admin");
@@ -114,6 +115,7 @@ const { RedisStore } = require("connect-redis");
   app.use("/api/contact", contactRoutes);
   app.use("/api/events", eventRoutes);
   app.use("/api/coalition", coalitionRoutes);
+  app.use("/api/coalition-signups", coalitionSignupRoutes);
   app.use("/api/event-signups", signupRoutes);
   app.use("/api/mailing-list", mailingListRoutes);
   app.use("/api/admin", adminRoutes);
@@ -142,6 +144,7 @@ const { RedisStore } = require("connect-redis");
   require("./models/mailingListSignup");
   require("./models/newsArticle");
   require("./models/coalitionCandidate");
+  require("./models/coalitionSignup");
 
   sequelize
     .sync({ alter: true })

--- a/frontend/src/pages/admin/admin.html
+++ b/frontend/src/pages/admin/admin.html
@@ -40,6 +40,12 @@
         <a href="#coalition" class="tab-button" data-target="coalition"
           >Coalition</a
         >
+        <a
+          href="#coalition-signups"
+          class="tab-button"
+          data-target="coalition-signups"
+          >Coalition Signups</a
+        >
         <a href="#messages" class="tab-button" data-target="messages"
           >Messages</a
         >
@@ -91,7 +97,12 @@
           <div class="coalition-form-grid">
             <label>
               <span>Candidate Name</span>
-              <input type="text" id="coalition-name" placeholder="Full name" required />
+              <input
+                type="text"
+                id="coalition-name"
+                placeholder="Full name"
+                required
+              />
             </label>
             <label>
               <span>Level</span>
@@ -174,7 +185,9 @@
           </label>
 
           <div class="coalition-form-actions">
-            <button type="submit" id="coalition-submit-btn">Add Candidate</button>
+            <button type="submit" id="coalition-submit-btn">
+              Add Candidate
+            </button>
             <button
               type="button"
               id="coalition-cancel-edit"
@@ -210,6 +223,22 @@
             </tr>
           </thead>
           <tbody id="coalition-table-body"></tbody>
+        </table>
+      </section>
+
+      <section id="coalition-signups" class="tab-content">
+        <h2>Coalition Signups</h2>
+        <table class="admin-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Phone</th>
+              <th>Zip</th>
+              <th>Submitted</th>
+            </tr>
+          </thead>
+          <tbody id="coalition-signups-table-body"></tbody>
         </table>
       </section>
 

--- a/frontend/src/pages/admin/scripts/adminPage.js
+++ b/frontend/src/pages/admin/scripts/adminPage.js
@@ -204,9 +204,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     );
     const links = [];
     rows.forEach((row) => {
-      const label = row
-        .querySelector(".coalition-social-label")
-        .value.trim();
+      const label = row.querySelector(".coalition-social-label").value.trim();
       const url = row.querySelector(".coalition-social-url").value.trim();
       if (label && url) {
         links.push({ label, url });
@@ -299,18 +297,18 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   if (coalitionForm) {
-  if (coalitionAddSocialLinkBtn) {
-    coalitionAddSocialLinkBtn.addEventListener("click", () => {
-      addSocialLinkRow();
-    });
-  }
+    if (coalitionAddSocialLinkBtn) {
+      coalitionAddSocialLinkBtn.addEventListener("click", () => {
+        addSocialLinkRow();
+      });
+    }
 
-  if (coalitionStatusFilterSelect) {
-    coalitionStatusFilterSelect.addEventListener("change", () => {
-      coalitionStatusFilter = coalitionStatusFilterSelect.value;
-      loadCoalitionCandidates();
-    });
-  }
+    if (coalitionStatusFilterSelect) {
+      coalitionStatusFilterSelect.addEventListener("change", () => {
+        coalitionStatusFilter = coalitionStatusFilterSelect.value;
+        loadCoalitionCandidates();
+      });
+    }
 
     if (coalitionCancelBtn) {
       coalitionCancelBtn.addEventListener("click", () => {
@@ -343,9 +341,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     coalitionForm.addEventListener("submit", async (e) => {
       e.preventDefault();
-      const name = coalitionForm
-        .querySelector("#coalition-name")
-        .value.trim();
+      const name = coalitionForm.querySelector("#coalition-name").value.trim();
       const level = coalitionForm
         .querySelector("#coalition-level")
         .value.trim();
@@ -376,7 +372,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       );
       formData.append(
         "sortOrder",
-        coalitionForm.querySelector("#coalition-sort-order").value.trim() || "0",
+        coalitionForm.querySelector("#coalition-sort-order").value.trim() ||
+          "0",
       );
 
       const tagsValue = coalitionForm
@@ -435,6 +432,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       loadNews(),
       loadEvents(),
       loadCoalitionCandidates(),
+      loadCoalitionSignups(),
     ]);
   }
 
@@ -564,6 +562,55 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     } catch (err) {
       console.error("Load signups error", err);
+    }
+  }
+
+  async function loadCoalitionSignups() {
+    const tbody = document.getElementById("coalition-signups-table-body");
+    if (!tbody) return;
+    tbody.innerHTML = "";
+
+    const renderMessageRow = (message) => {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      cell.colSpan = 5;
+      cell.textContent = message;
+      row.appendChild(cell);
+      tbody.appendChild(row);
+    };
+
+    try {
+      const res = await fetch("/api/admin/coalition-signups", {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        throw new Error("Failed to load coalition signups");
+      }
+
+      const data = await res.json();
+      if (!data.length) {
+        renderMessageRow("No coalition signups yet.");
+        return;
+      }
+
+      data.forEach((signup) => {
+        const row = document.createElement("tr");
+        const submittedAt = signup.createdAt
+          ? new Date(signup.createdAt).toLocaleString()
+          : "";
+
+        row.innerHTML = `
+          <td>${signup.name || ""}</td>
+          <td>${signup.email || ""}</td>
+          <td>${signup.phone || ""}</td>
+          <td>${signup.zip || ""}</td>
+          <td>${submittedAt}</td>
+        `;
+        tbody.appendChild(row);
+      });
+    } catch (err) {
+      console.error("Load coalition signups error", err);
+      renderMessageRow("Unable to load coalition signups.");
     }
   }
 
@@ -727,7 +774,10 @@ document.addEventListener("DOMContentLoaded", async () => {
           });
           if (res.ok) {
             await loadCoalitionCandidates();
-            if (editingCoalitionCandidate && editingCoalitionCandidate.id === candidate.id) {
+            if (
+              editingCoalitionCandidate &&
+              editingCoalitionCandidate.id === candidate.id
+            ) {
               resetCoalitionForm();
             }
           } else {
@@ -841,7 +891,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           edit.addEventListener("click", () => {
             eventIdInput.value = ev.id;
             document.getElementById("title").value = ev.title;
-            document.getElementById("eventDate").value = isoToLocalDatetimeValue(ev.eventDate);
+            document.getElementById("eventDate").value =
+              isoToLocalDatetimeValue(ev.eventDate);
             document.getElementById("location").value = ev.location || "";
             document.getElementById("description").value = ev.description || "";
             submitBtn.textContent = "Update Event";

--- a/frontend/src/pages/coalition/coalition.html
+++ b/frontend/src/pages/coalition/coalition.html
@@ -36,19 +36,24 @@
           <div class="coalition-hero__copy">
             <h1>Coalition for Montana's Future</h1>
             <p>
-              The only way that we defend our democratic values is by standing together,
-              with a unified voice on the issues that matter most to Montana. That is why,
-              as part of my campaign, Lux For Montana is proud to launch the Coalition for Montana's Future.
-              This coalition brings together local patriots running for office across the state,
-              from city council to Congress, who share our vision for a better Montana.
+              The only way that we defend our democratic values is by standing
+              together, with a unified voice on the issues that matter most to
+              Montana. That is why, as part of my campaign, Lux For Montana is
+              proud to launch the Coalition for Montana's Future. This coalition
+              brings together local patriots running for office across the
+              state, from city council to Congress, who share our vision for a
+              better Montana.
             </p>
             <p>
-              Together, we will go to our councils, state house, and Congress not just with promises,
-              but with a plan to deliver real results for our communities, and support in every level of government.
+              Together, we will go to our councils, state house, and Congress
+              not just with promises, but with a plan to deliver real results
+              for our communities, and support in every level of government.
             </p>
           </div>
           <div class="coalition-hero__actions">
-            <a class="btn btn-secondary" href="suggest-candidate.html">Suggest A Candidate</a>
+            <a class="btn btn-secondary" href="suggest-candidate.html"
+              >Suggest A Candidate</a
+            >
             <button
               type="button"
               class="coalition-hero__link coalition-hero__link--modal"
@@ -60,69 +65,117 @@
         </div>
       </section>
 
-      <section class="section coalition-filters">
-        <div class="container">
-          <div class="coalition-filters__header">
-            <h2>Find your next Representative</h2>
+      <section class="section coalition-countdown">
+        <div class="container coalition-countdown__content">
+          <div class="coalition-countdown__intro">
+            <h2>Countdown to Election Day</h2>
             <p>
-              Use the tools below to discover candidates by level of office,
-              priorities, and community.
+              We are pausing the candidate directory while we focus on
+              organizing for Election Day 2025. Check back soon for new
+              endorsements and ways to stand with our coalition in every corner
+              of the state.
+            </p>
+            <p
+              class="coalition-countdown__complete"
+              data-countdown-complete
+              hidden
+            >
+              Election Day is here! Thank you for organizing with us—check back
+              soon for updated coalition resources.
             </p>
           </div>
-          <div class="coalition-filters__controls">
-            <label>
-              <span>Level</span>
-              <select data-filter-level>
-                <option value="all">All</option>
-                <option value="federal">Federal</option>
-                <option value="state">State</option>
-                <option value="county">County</option>
-                <option value="city">City</option>
-              </select>
-            </label>
-            <label>
-              <span>Sort By</span>
-              <select data-filter-sort>
-                <option value="featured">Featured</option>
-                <option value="name">Name A–Z</option>
-                <option value="tag">Tag A–Z</option>
-              </select>
-            </label>
-            <label class="coalition-filters__search">
-              <span>Search</span>
-              <input
-                type="search"
-                placeholder="Search name, region, or issue focus"
-                data-filter-search
-              />
-            </label>
-          </div>
-          <div class="coalition-filter-tags">
-            <div class="coalition-filter-tags__header">
-              <span>Filter by tags</span>
-              <button type="button" class="secondary-btn" data-clear-tags hidden>
-                Clear tags
-              </button>
+          <div
+            class="coalition-countdown__timer"
+            data-countdown-timer
+            data-countdown-target="2025-11-05T00:00:00"
+            aria-live="polite"
+          >
+            <div class="coalition-countdown__unit">
+              <span
+                class="coalition-countdown__number"
+                data-countdown-value="days"
+                >0</span
+              >
+              <span class="coalition-countdown__label">Days</span>
             </div>
-            <div class="coalition-filter-tags__chips" data-filter-tags>
-              <p class="coalition-filter-tags__empty" data-tags-empty>
-                Tags will appear once the coalition loads.
-              </p>
+            <div class="coalition-countdown__unit">
+              <span
+                class="coalition-countdown__number"
+                data-countdown-value="hours"
+                >00</span
+              >
+              <span class="coalition-countdown__label">Hours</span>
+            </div>
+            <div class="coalition-countdown__unit">
+              <span
+                class="coalition-countdown__number"
+                data-countdown-value="minutes"
+                >00</span
+              >
+              <span class="coalition-countdown__label">Minutes</span>
+            </div>
+            <div class="coalition-countdown__unit">
+              <span
+                class="coalition-countdown__number"
+                data-countdown-value="seconds"
+                >00</span
+              >
+              <span class="coalition-countdown__label">Seconds</span>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="section coalition-directory">
-        <div class="container">
-          <div
-            class="coalition-directory__status"
-            data-coalition-status
-            aria-live="polite"
-          >
-            Loading coalition candidates…
+      <section class="section coalition-signup">
+        <div class="container coalition-signup__content">
+          <div class="coalition-signup__copy">
+            <h2>Join the Coalition Organizing List</h2>
+            <p>
+              Add your voice to the Coalition for Montana's Future so we can
+              stay in touch as new leaders join the slate. Sign up to receive
+              coalition updates, organizing opportunities, and Election Day
+              reminders.
+            </p>
           </div>
-          <div class="coalition-directory__groups" data-coalition-groups></div>
+          <form class="coalition-signup__form" data-coalition-form novalidate>
+            <div class="coalition-signup__fields">
+              <label>
+                <span>Full Name</span>
+                <input type="text" name="name" autocomplete="name" required />
+              </label>
+              <label>
+                <span>Email</span>
+                <input
+                  type="email"
+                  name="email"
+                  autocomplete="email"
+                  required
+                />
+              </label>
+              <label>
+                <span>Mobile Phone</span>
+                <input type="tel" name="phone" autocomplete="tel" required />
+              </label>
+              <label>
+                <span>Zip Code</span>
+                <input
+                  type="text"
+                  name="zip"
+                  inputmode="numeric"
+                  pattern="[0-9]{5}"
+                  maxlength="5"
+                  required
+                />
+              </label>
+            </div>
+            <div
+              class="coalition-signup__status"
+              data-coalition-form-status
+              role="status"
+              aria-live="polite"
+            ></div>
+            <button type="submit" class="btn btn-primary">Sign Up</button>
+          </form>
         </div>
       </section>
     </main>

--- a/frontend/src/pages/coalition/css/coalition.css
+++ b/frontend/src/pages/coalition/css/coalition.css
@@ -1,5 +1,9 @@
 .coalition-hero {
-  background: linear-gradient(135deg, rgba(57, 98, 137, 0.92), rgba(18, 46, 74, 0.92));
+  background: linear-gradient(
+    135deg,
+    rgba(57, 98, 137, 0.92),
+    rgba(18, 46, 74, 0.92)
+  );
   color: #ffffff;
   padding: calc(var(--section-vertical) * 0.8) 0;
 }
@@ -54,503 +58,180 @@
   border-color: #ffffff;
 }
 
-.coalition-hero__link i {
-  font-size: 0.95rem;
-}
-
-.coalition-filters {
+.coalition-countdown {
   background: var(--background-main);
   padding: var(--section-vertical) 0;
 }
 
-.coalition-filters__header {
-  max-width: 680px;
-  margin: 0 auto 2rem;
-  text-align: center;
-}
-
-.coalition-filters__controls {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: var(--radius);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
-  padding: 1.5rem;
-}
-
-.coalition-filters__controls label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-weight: 600;
-  color: var(--primary-color);
-}
-
-.coalition-filters__controls select,
-.coalition-filters__controls input[type="search"] {
-  padding: 0.75rem;
-  border-radius: var(--radius);
-  border: 1px solid rgba(57, 98, 137, 0.3);
-  font-size: 0.95rem;
-  background: #ffffff;
-}
-
-.coalition-filters__search {
-  grid-column: 1 / -1;
-}
-
-.coalition-filter-tags {
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: var(--radius);
-  padding: 1.5rem;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
-}
-
-.coalition-filter-tags__header {
+.coalition-countdown__content {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-weight: 600;
-  color: var(--primary-color);
-  margin-bottom: 0.75rem;
+  gap: 3rem;
 }
 
-.coalition-filter-tags__chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+.coalition-countdown__intro {
+  max-width: 640px;
 }
 
-.coalition-filter-tags__empty {
+.coalition-countdown__intro h2 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin-bottom: 1rem;
+}
+
+.coalition-countdown__intro p {
   margin: 0;
-  color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.75);
+  line-height: 1.6;
 }
 
-.coalition-tag-pill {
-  border: none;
-  padding: 0.45rem 0.9rem;
-  background: rgba(57, 98, 137, 0.12);
+.coalition-countdown__intro p + p {
+  margin-top: 1rem;
+}
+
+.coalition-countdown__timer {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(90px, 1fr));
+  gap: 1rem;
+  background: #ffffff;
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.1);
+  min-width: 360px;
+}
+
+.coalition-countdown__unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.coalition-countdown__number {
+  font-size: clamp(2.25rem, 5vw, 3rem);
+  font-weight: 700;
   color: var(--primary-color);
-  border-radius: 999px;
+  font-family: "Gideon Roman", serif;
+}
+
+.coalition-countdown__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
   font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease;
+  color: rgba(0, 0, 0, 0.65);
 }
 
-.coalition-tag-pill:hover {
-  transform: translateY(-1px);
-  background: rgba(57, 98, 137, 0.2);
+.coalition-countdown__complete {
+  background: rgba(57, 98, 137, 0.08);
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius);
+  font-weight: 600;
+  color: var(--primary-color);
 }
 
-.coalition-tag-pill[aria-pressed="true"] {
-  background: var(--secondary-color);
-  color: #ffffff;
-}
-
-.coalition-directory {
-  background: rgba(57, 98, 137, 0.05);
+.coalition-signup {
+  background: rgba(57, 98, 137, 0.06);
   padding: var(--section-vertical) 0;
 }
 
-.coalition-directory__status {
+.coalition-signup__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.coalition-signup__copy h2 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin-bottom: 1rem;
+}
+
+.coalition-signup__copy p {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.75);
+  line-height: 1.6;
+}
+
+.coalition-signup__form {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.08);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  text-align: center;
-  margin-bottom: 2rem;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.coalition-signup__fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.coalition-signup__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: var(--primary-color);
+}
+
+.coalition-signup__form input {
+  padding: 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(57, 98, 137, 0.35);
   font-size: 1rem;
+}
+
+.coalition-signup__form input:focus {
+  outline: 3px solid rgba(57, 98, 137, 0.25);
+  border-color: var(--secondary-color);
+}
+
+.coalition-signup__status {
+  min-height: 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
   color: rgba(0, 0, 0, 0.7);
 }
 
-.coalition-directory__status-action {
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  border: none;
-  background: rgba(57, 98, 137, 0.16);
-  color: var(--secondary-color);
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.coalition-directory__status-action:hover,
-.coalition-directory__status-action:focus-visible {
-  background: rgba(57, 98, 137, 0.28);
-  transform: translateY(-1px);
-}
-
-.coalition-directory__status-action:focus-visible {
-  outline: 3px solid rgba(57, 98, 137, 0.35);
-  outline-offset: 2px;
-}
-
-.coalition-directory__status[data-tone="warning"] {
-  color: #a35a18;
-}
-
-.coalition-directory__status[data-tone="error"] {
+.coalition-signup__status[data-state="error"] {
   color: #b3202a;
 }
 
-.coalition-group {
-  margin-bottom: 3rem;
+.coalition-signup__status[data-state="success"] {
+  color: #207245;
 }
 
-.coalition-group__heading {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
+.coalition-signup__form .btn {
+  align-self: flex-start;
 }
 
-.coalition-group__heading h2 {
-  margin: 0;
-  font-size: 2rem;
-  color: var(--primary-color);
-}
-
-.coalition-group__count {
-  font-size: 0.95rem;
-  color: rgba(0, 0, 0, 0.6);
-}
-
-.coalition-group__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.75rem;
-}
-
-.coalition-card {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 18px;
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.08);
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  min-height: 100%;
-  position: relative;
-  overflow: hidden;
-  backdrop-filter: blur(6px);
-}
-
-.coalition-card--focus {
-  box-shadow: 0 26px 60px rgba(57, 98, 137, 0.22);
-  border: 1px solid rgba(57, 98, 137, 0.35);
-}
-
-.coalition-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(140deg, rgba(57, 98, 137, 0.08), rgba(57, 98, 137, 0));
-  pointer-events: none;
-}
-
-.coalition-card__top {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.coalition-card__photo {
-  width: 76px;
-  height: 76px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 3px solid rgba(57, 98, 137, 0.25);
-  flex-shrink: 0;
-}
-
-.coalition-card__photo-placeholder {
-  width: 76px;
-  height: 76px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(57, 98, 137, 0.15);
-  color: var(--primary-color);
-  font-weight: 700;
-  font-size: 1.6rem;
-  border: 3px solid rgba(57, 98, 137, 0.25);
-  flex-shrink: 0;
-  text-transform: uppercase;
-}
-
-.coalition-card__identity {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.coalition-card__name {
-  margin: 0;
-  font-size: 1.25rem;
-  color: var(--primary-color);
-}
-
-.coalition-card__badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  background: rgba(57, 98, 137, 0.15);
-  color: var(--primary-color);
-  padding: 0.35rem 0.6rem;
-  border-radius: 999px;
-  font-weight: 700;
-}
-
-.coalition-card__office {
-  font-size: 0.95rem;
-  color: rgba(0, 0, 0, 0.7);
-  margin: 0;
-}
-
-.coalition-card__description {
-  font-size: 0.95rem;
-  color: rgba(0, 0, 0, 0.85);
-  margin: 0;
-}
-
-.coalition-card__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-}
-
-.coalition-card__compare {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  margin-top: 0.75rem;
-}
-
-.coalition-card__compare-btn {
-  border: none;
-  border-radius: 999px;
-  background: rgba(57, 98, 137, 0.16);
-  color: var(--secondary-color);
-  font-weight: 600;
-  padding: 0.45rem 0.9rem;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.coalition-card__compare-btn:hover,
-.coalition-card__compare-btn:focus-visible {
-  background: rgba(57, 98, 137, 0.26);
-  transform: translateY(-1px);
-}
-
-.coalition-card__compare-btn:focus-visible {
-  outline: 3px solid rgba(57, 98, 137, 0.32);
-  outline-offset: 2px;
-}
-
-.coalition-card__compare-btn:disabled {
-  cursor: default;
-  background: rgba(57, 98, 137, 0.1);
-  color: rgba(57, 98, 137, 0.65);
-  transform: none;
-}
-
-.coalition-card__match {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  background: rgba(57, 98, 137, 0.12);
-  color: var(--primary-color);
-}
-
-.coalition-card__match--focus {
-  background: var(--secondary-color);
-  color: #ffffff;
-}
-
-.coalition-card__match--muted {
-  background: rgba(0, 0, 0, 0.08);
-  color: rgba(0, 0, 0, 0.6);
-}
-
-.coalition-card__tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.6rem;
-  font-size: 0.8rem;
-  border-radius: 999px;
-  background: rgba(57, 98, 137, 0.12);
-  color: var(--primary-color);
-  font-weight: 600;
-}
-
-.coalition-card__links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  margin-top: auto;
-}
-
-.coalition-card__links a {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.7rem;
-  border-radius: 999px;
-  background: rgba(57, 98, 137, 0.1);
-  color: var(--secondary-color);
-  font-weight: 600;
-  text-decoration: none;
-  transition: background 0.2s ease;
-}
-
-.coalition-card__links a i {
-  font-size: 0.95rem;
-}
-
-.coalition-card__links a:hover {
-  background: rgba(57, 98, 137, 0.2);
-}
-
-@media (prefers-color-scheme: dark) {
-  .coalition-hero {
-    background: linear-gradient(135deg, rgba(57, 98, 137, 0.88), rgba(23, 45, 68, 0.88));
-  }
-
-  .coalition-filters,
-  .coalition-directory {
-    background: rgba(9, 18, 28, 0.95);
-  }
-
-  .coalition-filters__header,
-  .coalition-filter-tags__header,
-  .coalition-directory__status,
-  .coalition-group__count {
-    color: rgba(255, 255, 255, 0.75);
-  }
-
-  .coalition-directory__status[data-tone="warning"] {
-    color: #ffb25b;
-  }
-
-  .coalition-directory__status[data-tone="error"] {
-    color: #ff8a8a;
-  }
-
-  .coalition-filters__controls,
-  .coalition-filter-tags,
-  .coalition-card {
-    background: rgba(18, 28, 40, 0.92);
-    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
-  }
-
-  .coalition-card--focus {
-    box-shadow: 0 28px 65px rgba(57, 98, 137, 0.35);
-    border-color: rgba(118, 169, 227, 0.55);
-  }
-
-  .coalition-filters__controls select,
-  .coalition-filters__controls input[type="search"] {
-    background: rgba(12, 20, 30, 0.9);
-    border-color: rgba(255, 255, 255, 0.15);
-    color: rgba(255, 255, 255, 0.9);
-  }
-
-  .coalition-card__description,
-  .coalition-card__office {
-    color: rgba(255, 255, 255, 0.8);
-  }
-
-  .coalition-card__compare-btn {
-    background: rgba(57, 98, 137, 0.35);
-    color: #e9f0f6;
-  }
-
-  .coalition-card__compare-btn:hover,
-  .coalition-card__compare-btn:focus-visible {
-    background: rgba(57, 98, 137, 0.45);
-  }
-
-  .coalition-card__compare-btn:disabled {
-    background: rgba(57, 98, 137, 0.2);
-    color: rgba(233, 240, 246, 0.7);
-  }
-
-  .coalition-card__links a {
-    background: rgba(57, 98, 137, 0.25);
-    color: #e9f0f6;
-  }
-
-  .coalition-card__links a:hover {
-    background: rgba(57, 98, 137, 0.35);
-  }
-
-  .coalition-card__match {
-    background: rgba(57, 98, 137, 0.35);
-    color: #e9f0f6;
-  }
-
-  .coalition-card__match--focus {
-    background: var(--secondary-color);
-    color: #ffffff;
-  }
-
-  .coalition-card__match--muted {
-    background: rgba(255, 255, 255, 0.18);
-    color: rgba(255, 255, 255, 0.65);
-  }
-
-  .coalition-directory__status-action {
-    background: rgba(57, 98, 137, 0.3);
-    color: #e9f0f6;
-  }
-
-  .coalition-directory__status-action:hover,
-  .coalition-directory__status-action:focus-visible {
-    background: rgba(57, 98, 137, 0.4);
-  }
-
-}
-
-@media (max-width: 900px) {
-  .coalition-hero__content {
+@media (max-width: 960px) {
+  .coalition-hero__content,
+  .coalition-countdown__content {
     flex-direction: column;
-    align-items: flex-start;
+    text-align: center;
   }
 
   .coalition-hero__actions {
-    width: 100%;
+    align-items: center;
   }
 
-  .coalition-hero__actions .btn {
+  .coalition-countdown__timer {
+    min-width: 0;
     width: 100%;
-    text-align: center;
   }
 }
 
 @media (max-width: 600px) {
-  .coalition-filters__controls {
-    padding: 1.25rem;
+  .coalition-countdown__timer {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    gap: 1.25rem 0.75rem;
   }
 
-  .coalition-group__grid {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.25rem;
-  }
-
-  .coalition-card {
-    padding: 1.25rem;
+  .coalition-signup__form {
+    padding: 1.5rem;
   }
 }

--- a/frontend/src/pages/coalition/scripts/coalitionPage.js
+++ b/frontend/src/pages/coalition/scripts/coalitionPage.js
@@ -1,674 +1,130 @@
-const LEVEL_ORDER = ["federal", "state", "county", "city"];
-const LEVEL_LABELS = {
-  federal: "Federal",
-  state: "State",
-  county: "County",
-  city: "City",
-  other: "Community",
-};
+function initCountdown() {
+  const timer = document.querySelector("[data-countdown-timer]");
+  if (!timer) return;
 
-const SOCIAL_ICON_MAP = [
-  { match: /facebook|meta/, icon: "fa-brands fa-facebook-f" },
-  { match: /instagram/, icon: "fa-brands fa-instagram" },
-  { match: /twitter|x\b/, icon: "fa-brands fa-x-twitter" },
-  { match: /bluesky/, icon: "fa-brands fa-bluesky" },
-  { match: /threads/, icon: "fa-brands fa-threads" },
-  { match: /mastodon/, icon: "fa-brands fa-mastodon" },
-  { match: /tiktok/, icon: "fa-brands fa-tiktok" },
-  { match: /youtube|video/, icon: "fa-brands fa-youtube" },
-  { match: /linkedin/, icon: "fa-brands fa-linkedin-in" },
-  { match: /email|contact/, icon: "fa-solid fa-envelope" },
-];
+  const targetDateAttr = timer.dataset.countdownTarget;
+  const targetDate = targetDateAttr ? new Date(targetDateAttr) : null;
+  const completedMessage = document.querySelector("[data-countdown-complete]");
 
-function getSocialIcon(label) {
-  const lower = label.toLowerCase();
-  const matched = SOCIAL_ICON_MAP.find(({ match }) => match.test(lower));
-  if (matched) return matched.icon;
-  if (lower.includes("website") || lower.includes("site")) {
-    return "fa-solid fa-globe";
+  if (!targetDate || Number.isNaN(targetDate.getTime())) {
+    if (completedMessage) {
+      completedMessage.hidden = false;
+      completedMessage.textContent =
+        "Election Day is approaching. Check back soon for updates.";
+    }
+    return;
   }
-  return "fa-solid fa-arrow-up-right-from-square";
+
+  const valueElements = {
+    days: timer.querySelector('[data-countdown-value="days"]'),
+    hours: timer.querySelector('[data-countdown-value="hours"]'),
+    minutes: timer.querySelector('[data-countdown-value="minutes"]'),
+    seconds: timer.querySelector('[data-countdown-value="seconds"]'),
+  };
+
+  function setValue(key, value) {
+    const element = valueElements[key];
+    if (!element) return;
+    const normalizedValue = Math.max(value, 0);
+    element.textContent =
+      key === "days"
+        ? String(normalizedValue)
+        : String(normalizedValue).padStart(2, "0");
+  }
+
+  function updateTimer() {
+    const now = new Date();
+    const diff = targetDate.getTime() - now.getTime();
+
+    if (diff <= 0) {
+      setValue("days", 0);
+      setValue("hours", 0);
+      setValue("minutes", 0);
+      setValue("seconds", 0);
+      if (completedMessage) completedMessage.hidden = false;
+      clearInterval(intervalId);
+      return;
+    }
+
+    const secondsTotal = Math.floor(diff / 1000);
+    const days = Math.floor(secondsTotal / (60 * 60 * 24));
+    const hours = Math.floor((secondsTotal % (60 * 60 * 24)) / (60 * 60));
+    const minutes = Math.floor((secondsTotal % (60 * 60)) / 60);
+    const seconds = secondsTotal % 60;
+
+    setValue("days", days);
+    setValue("hours", hours);
+    setValue("minutes", minutes);
+    setValue("seconds", seconds);
+  }
+
+  updateTimer();
+  const intervalId = setInterval(updateTimer, 1000);
 }
 
-function formatLevel(level) {
-  if (!level) return LEVEL_LABELS.other;
-  return LEVEL_LABELS[level] || LEVEL_LABELS.other;
-}
+function initCoalitionSignupForm() {
+  const form = document.querySelector("[data-coalition-form]");
+  if (!form) return;
 
-function getPrimaryTag(candidate) {
-  if (!candidate.tags || candidate.tags.length === 0) return "zzzz";
-  const copy = [...candidate.tags];
-  copy.sort((a, b) => a.localeCompare(b));
-  return copy[0];
-}
+  const status = form.querySelector("[data-coalition-form-status]");
+  const submitButton = form.querySelector('button[type="submit"]');
 
-function normalizeCandidates(rawCandidates) {
-  return rawCandidates.map((candidate) => {
-    const normalizedId =
-      candidate && candidate.id !== undefined && candidate.id !== null
-        ? String(candidate.id)
-        : null;
+  function setStatus(message, state = "info") {
+    if (!status) return;
+    status.textContent = message;
+    if (state) status.dataset.state = state;
+    else delete status.dataset.state;
+  }
 
-    return {
-      ...candidate,
-      id: normalizedId,
-      tags: Array.isArray(candidate.tags)
-        ? candidate.tags.map((tag) => String(tag))
-        : [],
-      socialLinks: Array.isArray(candidate.socialLinks)
-        ? candidate.socialLinks
-            .filter((link) => link && link.url)
-            .map((link) => ({
-              label: link.label ? String(link.label) : "Follow",
-              url: String(link.url),
-            }))
-        : [],
-      sortOrder: Number(candidate.sortOrder) || 0,
-      websiteUrl: candidate.websiteUrl ? String(candidate.websiteUrl) : "",
-    };
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const name = (formData.get("name") || "").toString().trim();
+    const email = (formData.get("email") || "").toString().trim();
+    const phone = (formData.get("phone") || "").toString().trim();
+    const zip = (formData.get("zip") || "").toString().trim();
+
+    if (!name || !email || !phone || !zip) {
+      setStatus("Please complete all fields before submitting.", "error");
+      return;
+    }
+
+    setStatus("Submitting your information…");
+    if (submitButton) submitButton.disabled = true;
+
+    try {
+      const res = await fetch("/api/coalition-signups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, phone, zip }),
+      });
+
+      if (!res.ok) {
+        const data = await res
+          .json()
+          .catch(() => ({ error: "Unable to save your sign up." }));
+        throw new Error(data.error || "Unable to save your sign up.");
+      }
+
+      form.reset();
+      setStatus(
+        "Thanks for joining the coalition! We'll be in touch soon.",
+        "success",
+      );
+    } catch (err) {
+      console.error("Coalition signup failed", err);
+      setStatus(
+        err.message || "We couldn't process your sign up. Please try again.",
+        "error",
+      );
+    } finally {
+      if (submitButton) submitButton.disabled = false;
+    }
   });
 }
 
-function debounce(fn, delay = 180) {
-  let timeoutId;
-  return (...args) => {
-    if (timeoutId) clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => fn(...args), delay);
-  };
-}
-
 export default function initCoalitionPage() {
-  const groupsContainer = document.querySelector("[data-coalition-groups]");
-  if (!groupsContainer) return;
-
-  const statusEl = document.querySelector("[data-coalition-status]");
-  const tagContainer = document.querySelector("[data-filter-tags]");
-  const tagsEmptyEl = document.querySelector("[data-tags-empty]");
-  const clearTagsBtn = document.querySelector("[data-clear-tags]");
-  const levelSelect = document.querySelector("[data-filter-level]");
-  const sortSelect = document.querySelector("[data-filter-sort]");
-  const searchInput = document.querySelector("[data-filter-search]");
-
-  const state = {
-    candidates: [],
-    tags: [],
-  };
-  const filters = {
-    level: "all",
-    sort: "featured",
-    search: "",
-    tags: new Set(),
-    sharedFocusId: null,
-  };
-
-  function updateStatus(message, tone = "default", options = {}) {
-    if (!statusEl) return;
-    statusEl.dataset.tone = tone;
-    statusEl.innerHTML = "";
-
-    const textSpan = document.createElement("span");
-    textSpan.textContent = message;
-    statusEl.appendChild(textSpan);
-
-    if (options.action) {
-      statusEl.appendChild(options.action);
-    }
-  }
-
-  function createStatusAction(label, onClick) {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "coalition-directory__status-action";
-    button.textContent = label;
-    button.addEventListener("click", onClick);
-    return button;
-  }
-
-  function createClearSharedFocusButton() {
-    return createStatusAction("Clear shared priorities", () => {
-      clearSharedFocus();
-    });
-  }
-
-  function clearSharedFocus({ silent = false } = {}) {
-    if (!filters.sharedFocusId) return false;
-    filters.sharedFocusId = null;
-    if (!silent) {
-      applyFilters();
-    }
-    return true;
-  }
-
-  function startSharedFocus(candidate) {
-    if (!candidate || !candidate.id) return;
-    if (filters.sharedFocusId === candidate.id) return;
-    filters.sharedFocusId = candidate.id;
-    applyFilters();
-  }
-
-  function renderTagControls() {
-    if (!tagContainer) return;
-    tagContainer.innerHTML = "";
-
-    if (!state.tags.length) {
-      if (tagsEmptyEl) tagsEmptyEl.hidden = false;
-      if (clearTagsBtn) clearTagsBtn.hidden = true;
-      return;
-    }
-
-    if (tagsEmptyEl) tagsEmptyEl.hidden = true;
-    state.tags.forEach((tag) => {
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = "coalition-tag-pill";
-      button.textContent = tag;
-      button.setAttribute(
-        "aria-pressed",
-        filters.tags.has(tag) ? "true" : "false",
-      );
-      button.addEventListener("click", () => {
-        clearSharedFocus({ silent: true });
-        if (filters.tags.has(tag)) filters.tags.delete(tag);
-        else filters.tags.add(tag);
-        applyFilters();
-      });
-      tagContainer.appendChild(button);
-    });
-
-    if (clearTagsBtn) {
-      clearTagsBtn.hidden = filters.tags.size === 0;
-    }
-  }
-
-  function sortEntries(entries) {
-    const cloned = [...entries];
-    cloned.sort((a, b) => {
-      if (filters.sort === "name") {
-        const nameCompare = a.name.localeCompare(b.name);
-        if (nameCompare !== 0) return nameCompare;
-        return a.sortOrder - b.sortOrder;
-      }
-      if (filters.sort === "tag") {
-        const tagA = getPrimaryTag(a);
-        const tagB = getPrimaryTag(b);
-        if (tagA !== tagB) return tagA.localeCompare(tagB);
-        return a.name.localeCompare(b.name);
-      }
-      if (a.sortOrder !== b.sortOrder) {
-        return a.sortOrder - b.sortOrder;
-      }
-      return a.name.localeCompare(b.name);
-    });
-    return cloned;
-  }
-
-  function renderCandidates(filtered, options = {}) {
-    const {
-      sharedFocusId = null,
-      matchMeta = new Map(),
-      onCompareClick = null,
-      disableSort = false,
-    } = options;
-
-    groupsContainer.innerHTML = "";
-    const grouped = {};
-    filtered.forEach((candidate) => {
-      const level = LEVEL_ORDER.includes(candidate.jurisdictionLevel)
-        ? candidate.jurisdictionLevel
-        : "other";
-      if (!grouped[level]) grouped[level] = [];
-      grouped[level].push(candidate);
-    });
-
-    const orderedLevels = LEVEL_ORDER.filter((level) => grouped[level]?.length);
-    if (grouped.other && grouped.other.length) orderedLevels.push("other");
-
-    const fragment = document.createDocumentFragment();
-    orderedLevels.forEach((level) => {
-      const levelCandidates = disableSort
-        ? [...grouped[level]]
-        : sortEntries(grouped[level]);
-      const wrapper = document.createElement("section");
-      wrapper.className = "coalition-group";
-
-      const heading = document.createElement("div");
-      heading.className = "coalition-group__heading";
-
-      const title = document.createElement("h2");
-      title.textContent = formatLevel(level);
-      heading.appendChild(title);
-
-      const count = document.createElement("span");
-      count.className = "coalition-group__count";
-      count.textContent = `${levelCandidates.length} candidate${levelCandidates.length === 1 ? "" : "s"}`;
-      heading.appendChild(count);
-
-      wrapper.appendChild(heading);
-
-      const grid = document.createElement("div");
-      grid.className = "coalition-group__grid";
-      levelCandidates.forEach((candidate) => {
-        const card = createCandidateCard(candidate, {
-          onCompareClick,
-          isFocus: sharedFocusId === candidate.id,
-          matchMeta:
-            matchMeta instanceof Map ? matchMeta.get(candidate.id) : undefined,
-        });
-        grid.appendChild(card);
-      });
-      wrapper.appendChild(grid);
-      fragment.appendChild(wrapper);
-    });
-
-    groupsContainer.appendChild(fragment);
-  }
-
-  function buildMatchIndicator(meta, isFocus) {
-    if (!meta) return null;
-    const badge = document.createElement("span");
-    badge.className = "coalition-card__match";
-
-    if (meta.type === "focus") {
-      const total = meta.total || 0;
-      const label = total === 1 ? "Focus priority" : "Focus priorities";
-      badge.textContent = `${label} • ${total}`;
-      badge.classList.add("coalition-card__match--focus");
-      return badge;
-    }
-
-    if (meta.type === "match") {
-      const count = meta.count || 0;
-      const percent = meta.percent ?? 0;
-      badge.textContent = `${count} shared ${count === 1 ? "priority" : "priorities"} • ${percent}% overlap`;
-      return badge;
-    }
-
-    if (meta.type === "emptyFocus") {
-      badge.textContent = "No priorities listed yet";
-      badge.classList.add("coalition-card__match--muted");
-      return badge;
-    }
-
-    if (isFocus) {
-      badge.textContent = "Focus priorities";
-      badge.classList.add("coalition-card__match--focus");
-      return badge;
-    }
-
-    return null;
-  }
-
-  function createCandidateCard(candidate, options = {}) {
-    const { onCompareClick, isFocus = false, matchMeta = null } = options;
-
-    const card = document.createElement("article");
-    card.className = "coalition-card";
-    if (isFocus) {
-      card.classList.add("coalition-card--focus");
-    }
-
-    const top = document.createElement("div");
-    top.className = "coalition-card__top";
-
-    if (candidate.headshotImage) {
-      const img = document.createElement("img");
-      img.src = candidate.headshotImage;
-      img.alt = `${candidate.name} headshot`;
-      img.className = "coalition-card__photo";
-      top.appendChild(img);
-    } else {
-      const placeholder = document.createElement("div");
-      placeholder.className = "coalition-card__photo-placeholder";
-      placeholder.textContent = candidate.name
-        ? candidate.name.charAt(0).toUpperCase()
-        : "?";
-      top.appendChild(placeholder);
-    }
-
-    const identity = document.createElement("div");
-    identity.className = "coalition-card__identity";
-
-    const badge = document.createElement("span");
-    badge.className = "coalition-card__badge";
-    badge.textContent = formatLevel(candidate.jurisdictionLevel);
-    identity.appendChild(badge);
-
-    const name = document.createElement("h3");
-    name.className = "coalition-card__name";
-    name.textContent = candidate.name;
-    identity.appendChild(name);
-
-    const officeLine = [candidate.office, candidate.region].filter(Boolean).join(" • ");
-    if (officeLine) {
-      const office = document.createElement("p");
-      office.className = "coalition-card__office";
-      office.textContent = officeLine;
-      identity.appendChild(office);
-    }
-
-    top.appendChild(identity);
-    card.appendChild(top);
-
-    if (candidate.description) {
-      const description = document.createElement("p");
-      description.className = "coalition-card__description";
-      description.textContent = candidate.description;
-      card.appendChild(description);
-    }
-
-    if (candidate.tags.length) {
-      const tagsWrapper = document.createElement("div");
-      tagsWrapper.className = "coalition-card__tags";
-      candidate.tags.forEach((tag) => {
-        const pill = document.createElement("span");
-        pill.className = "coalition-card__tag";
-        pill.textContent = tag;
-        tagsWrapper.appendChild(pill);
-      });
-      card.appendChild(tagsWrapper);
-    }
-
-    const compareRow = document.createElement("div");
-    compareRow.className = "coalition-card__compare";
-    let hasCompareContent = false;
-
-    if (typeof onCompareClick === "function") {
-      const compareButton = document.createElement("button");
-      compareButton.type = "button";
-      compareButton.className = "coalition-card__compare-btn";
-      compareButton.textContent = isFocus
-        ? "Viewing shared priorities"
-        : "Find shared priorities";
-      compareButton.disabled = Boolean(isFocus);
-      compareButton.addEventListener("click", () => {
-        onCompareClick(candidate);
-      });
-      compareRow.appendChild(compareButton);
-      hasCompareContent = true;
-    }
-
-    const indicator = buildMatchIndicator(matchMeta, isFocus);
-    if (indicator) {
-      compareRow.appendChild(indicator);
-      hasCompareContent = true;
-    }
-
-    if (hasCompareContent) {
-      card.appendChild(compareRow);
-    }
-
-    const linksWrapper = document.createElement("div");
-    linksWrapper.className = "coalition-card__links";
-
-    if (candidate.websiteUrl) {
-      linksWrapper.appendChild(createLink("Website", candidate.websiteUrl));
-    }
-
-    candidate.socialLinks.forEach((link) => {
-      if (!link.url) return;
-      linksWrapper.appendChild(createLink(link.label || "Follow", link.url));
-    });
-
-    if (linksWrapper.childElementCount) {
-      card.appendChild(linksWrapper);
-    }
-
-    return card;
-  }
-
-  function createLink(label, url) {
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.target = "_blank";
-    anchor.rel = "noopener noreferrer";
-    const icon = document.createElement("i");
-    icon.className = getSocialIcon(label);
-    anchor.appendChild(icon);
-    const text = document.createElement("span");
-    text.textContent = label;
-    anchor.appendChild(text);
-    return anchor;
-  }
-
-  function applyFilters() {
-    if (!state.candidates.length) {
-      updateStatus("No coalition members published yet. Check back soon.");
-      groupsContainer.innerHTML = "";
-      renderTagControls();
-      return;
-    }
-
-    if (filters.sharedFocusId) {
-      const focusCandidate = state.candidates.find(
-        (candidate) => candidate.id === filters.sharedFocusId,
-      );
-
-      if (!focusCandidate) {
-        filters.sharedFocusId = null;
-        applyFilters();
-        return;
-      }
-
-      const focusTags = Array.from(new Set(focusCandidate.tags || []));
-      const focusTagSet = new Set(focusTags);
-      const statusAction = createClearSharedFocusButton();
-
-      if (!focusTags.length) {
-        updateStatus(
-          `${focusCandidate.name} has no priorities listed yet.`,
-          "warning",
-          { action: statusAction },
-        );
-        const matchMeta = new Map();
-        matchMeta.set(focusCandidate.id, { type: "emptyFocus" });
-        renderCandidates([focusCandidate], {
-          sharedFocusId: focusCandidate.id,
-          matchMeta,
-          onCompareClick: startSharedFocus,
-          disableSort: true,
-        });
-        renderTagControls();
-        return;
-      }
-
-      const matches = state.candidates
-        .filter((candidate) => candidate.id !== focusCandidate.id)
-        .map((candidate) => {
-          const overlapCount = (candidate.tags || []).reduce((count, tag) => {
-            return count + (focusTagSet.has(tag) ? 1 : 0);
-          }, 0);
-          return {
-            candidate,
-            overlapCount,
-            percent: focusTags.length
-              ? Math.round((overlapCount / focusTags.length) * 100)
-              : 0,
-          };
-        })
-        .filter((entry) => entry.overlapCount > 0);
-
-      if (!matches.length) {
-        updateStatus(
-          `No other candidates share priorities with ${focusCandidate.name} yet.`,
-          "warning",
-          { action: statusAction },
-        );
-        const matchMeta = new Map();
-        matchMeta.set(focusCandidate.id, {
-          type: "focus",
-          total: focusTags.length,
-        });
-        renderCandidates([focusCandidate], {
-          sharedFocusId: focusCandidate.id,
-          matchMeta,
-          onCompareClick: startSharedFocus,
-          disableSort: true,
-        });
-        renderTagControls();
-        return;
-      }
-
-      const maxOverlap = Math.max(...matches.map((entry) => entry.overlapCount));
-      const topMatches = matches.filter(
-        (entry) => entry.overlapCount === maxOverlap,
-      );
-
-      const results = [focusCandidate, ...topMatches.map((entry) => entry.candidate)];
-      const matchMeta = new Map();
-      matchMeta.set(focusCandidate.id, {
-        type: "focus",
-        total: focusTags.length,
-      });
-      topMatches.forEach((entry) => {
-        matchMeta.set(entry.candidate.id, {
-          type: "match",
-          count: entry.overlapCount,
-          percent: entry.percent,
-          total: focusTags.length,
-        });
-      });
-
-      const matchCount = topMatches.length;
-      updateStatus(
-        `Showing ${matchCount} candidate${matchCount === 1 ? "" : "s"} sharing ${maxOverlap} priority${maxOverlap === 1 ? "" : "ies"} with ${focusCandidate.name}.`,
-        "default",
-        { action: statusAction },
-      );
-
-      renderCandidates(results, {
-        sharedFocusId: focusCandidate.id,
-        matchMeta,
-        onCompareClick: startSharedFocus,
-        disableSort: true,
-      });
-      renderTagControls();
-      return;
-    }
-
-    let filtered = state.candidates;
-
-    if (filters.level !== "all") {
-      filtered = filtered.filter(
-        (candidate) => candidate.jurisdictionLevel === filters.level,
-      );
-    }
-
-    if (filters.tags.size) {
-      filtered = filtered.filter((candidate) => {
-        if (!candidate.tags || !candidate.tags.length) return false;
-        return [...filters.tags].every((tag) => candidate.tags.includes(tag));
-      });
-    }
-
-    if (filters.search) {
-      const searchLower = filters.search.toLowerCase();
-      filtered = filtered.filter((candidate) => {
-        const haystack = [
-          candidate.name,
-          candidate.office,
-          candidate.region,
-          candidate.description,
-          (candidate.tags || []).join(" "),
-        ]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        return haystack.includes(searchLower);
-      });
-    }
-
-    if (!filtered.length) {
-      updateStatus(
-        "No candidates match those filters yet. Try selecting fewer tags.",
-        "warning",
-      );
-      groupsContainer.innerHTML = "";
-      renderTagControls();
-      return;
-    }
-
-    const total = state.candidates.length;
-    if (
-      filters.level === "all" &&
-      !filters.tags.size &&
-      !filters.search &&
-      filters.sort === "featured"
-    ) {
-      updateStatus(`${filtered.length} coalition candidates ready to explore.`);
-    } else {
-      updateStatus(
-        `${filtered.length} of ${total} candidates match your filters.`,
-      );
-    }
-
-    renderCandidates(filtered, { onCompareClick: startSharedFocus });
-    renderTagControls();
-  }
-
-  function hydrateFiltersFromData() {
-    const tagSet = new Set();
-    state.candidates.forEach((candidate) => {
-      (candidate.tags || []).forEach((tag) => {
-        tagSet.add(tag);
-      });
-    });
-    state.tags = [...tagSet].sort((a, b) => a.localeCompare(b));
-    renderTagControls();
-  }
-
-  async function fetchCandidates() {
-    try {
-      updateStatus("Loading coalition candidates…");
-      const res = await fetch("/api/coalition");
-      if (!res.ok) throw new Error(`Request failed with ${res.status}`);
-      const data = await res.json();
-      state.candidates = normalizeCandidates(data);
-      hydrateFiltersFromData();
-      applyFilters();
-    } catch (err) {
-      console.error("Coalition fetch error", err);
-      updateStatus(
-        "We couldn't load the coalition right now. Please try again soon.",
-        "error",
-      );
-      groupsContainer.innerHTML = "";
-    }
-  }
-
-  if (levelSelect) {
-    levelSelect.addEventListener("change", () => {
-      clearSharedFocus({ silent: true });
-      filters.level = levelSelect.value;
-      applyFilters();
-    });
-  }
-
-  if (sortSelect) {
-    sortSelect.addEventListener("change", () => {
-      clearSharedFocus({ silent: true });
-      filters.sort = sortSelect.value;
-      applyFilters();
-    });
-  }
-
-  if (searchInput) {
-    const updateSearch = debounce((value) => {
-      filters.search = value.trim();
-      applyFilters();
-    }, 200);
-    searchInput.addEventListener("input", (event) => {
-      clearSharedFocus({ silent: true });
-      updateSearch(event.target.value);
-    });
-  }
-
-  if (clearTagsBtn) {
-    clearTagsBtn.addEventListener("click", () => {
-      clearSharedFocus({ silent: true });
-      filters.tags.clear();
-      applyFilters();
-    });
-  }
-
-  fetchCandidates();
+  initCountdown();
+  initCoalitionSignupForm();
 }

--- a/frontend/src/scripts/campaignFinanceData.js
+++ b/frontend/src/scripts/campaignFinanceData.js
@@ -198,7 +198,7 @@ export const fetchFinanceSummary = async () => {
     (async () => {
       try {
         return await fetchSheet(TRANSACTIONS_SHEET_NAME);
-      } catch (error) {
+      } catch {
         return [];
       }
     })(),


### PR DESCRIPTION
## Summary
- replace the coalition directory UI with an election countdown and coalition signup form
- add backend storage and API endpoints for coalition signups and surface them in the admin dashboard
- expose coalition signup submissions through a new admin tab with sortable data

## Testing
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e0d6f78ac88328a12295de18490d59